### PR TITLE
Docking: Simplify logic of moving tabs between nodes. Amends 0abe7d. …

### DIFF
--- a/imgui.cpp
+++ b/imgui.cpp
@@ -14749,19 +14749,12 @@ static void ImGui::DockNodeMoveWindows(ImGuiDockNode* dst_node, ImGuiDockNode* s
         src_node->TabBar = NULL;
     }
 
-    for (int n_from_node = 0, n_from_tab_bar = 0; n_from_node < src_node->Windows.Size; n_from_node++, n_from_tab_bar++)
+    // Tab order is not important here, it is preserved by sorting in DockNodeUpdateTabBar().
+    for (ImGuiWindow* window : src_node->Windows)
     {
-        // DockNode's TabBar may have non-window Tabs manually appended by user
-        while (src_tab_bar && src_tab_bar->Tabs[n_from_tab_bar].Window == NULL)
-            n_from_tab_bar++;
-
-        // Using TabBar order (FIXME: Why? Clarify + add tests for it)
-        if (ImGuiWindow* window = src_tab_bar ? src_tab_bar->Tabs[n_from_tab_bar].Window : src_node->Windows[n_from_node])
-        {
-            window->DockNode = NULL;
-            window->DockIsActive = false;
-            DockNodeAddWindow(dst_node, window, move_tab_bar ? false : true);
-        }
+        window->DockNode = NULL;
+        window->DockIsActive = false;
+        DockNodeAddWindow(dst_node, window, !move_tab_bar);
     }
     src_node->Windows.clear();
 


### PR DESCRIPTION
…(#5515)

The idea is that in the absence of a tab bar, as new one gets created new tabs will be sorted based on window->DockOrder so this may work but we're not 100% sure.

(Click "Preview" to turn any http URL into a clickable link)

1. PLEASE CAREFULLY READ: [Contributing Guidelines](https://github.com/ocornut/imgui/blob/master/docs/CONTRIBUTING.md)

2. Clear this template before submitting your PR.

